### PR TITLE
add slack channel info

### DIFF
--- a/intro_stdpopsim/Intro_stdpopsim.ipynb
+++ b/intro_stdpopsim/Intro_stdpopsim.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "**Instructor:** Jerome Kelleher, University of Oxford\n",
     "\n",
-    "**Helpers:** Ariella Gladstein, David Peede, Peter Ralph\n",
+    "**Helpers:** Ariella Gladstein, David Peede, Peter Ralph (slack channel: #dec7-8_transatlantic)\n",
     "\n",
     "### Americas\n",
     "\n",
@@ -29,7 +29,7 @@
     "\n",
     "**Instructor:** Andy Kern, University of Oregon\n",
     "\n",
-    "**Helpers:** Peter Ralph, David Peede, Ilan Gronau\n",
+    "**Helpers:** Peter Ralph, David Peede, Ilan Gronau (slack channel: #dec9-10_americas)\n",
     "\n",
     "### Australasia\n",
     "\n",
@@ -37,14 +37,14 @@
     "\n",
     "**Instructor:** Georgia Tsambos, University of Melbourne\n",
     "\n",
-    "**Helpers:** Murillo Rodrigues, Peter Ralph \n",
+    "**Helpers:** Murillo Rodrigues, Peter Ralph (slack channel: #dec10-11_australasia)\n",
     "\n",
     "## Workshop logistics\n",
     "\n",
     "**Participants:** If you want, introduce yourselves in the Slack chat. What's your name? Where are you located? What do you work on?\n",
     "\n",
     "**Banter/Questions**\n",
-    "Please use the Slack #dec7-8_transatlantic channel for participant-participant help and chat. To ask a general question, simply write it in the channel, and to ask for one-one help DM one of the helpers in your session.\n",
+    "Please use the Slack channel you were invited to for participant-participant help and chat. To ask a general question, simply write it in the channel, and to ask for one-one help DM one of the helpers in your session.\n",
     "\n",
     "This worksheet was created by Ariella Gladstein, a postdoc at University of North Carolina, Chapel Hill."
    ]
@@ -962,7 +962,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/intro_stdpopsim/Intro_stdpopsim_fillme.ipynb
+++ b/intro_stdpopsim/Intro_stdpopsim_fillme.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "**Instructor:** Jerome Kelleher, University of Oxford\n",
     "\n",
-    "**Helpers:** Ariella Gladstein, David Peede, Peter Ralph\n",
+    "**Helpers:** Ariella Gladstein, David Peede, Peter Ralph (slack channel: #dec7-8_transatlantic)\n",
     "\n",
     "### Americas\n",
     "\n",
@@ -29,7 +29,7 @@
     "\n",
     "**Instructor:** Andy Kern, University of Oregon\n",
     "\n",
-    "**Helpers:** Peter Ralph, David Peede, Ilan Gronau\n",
+    "**Helpers:** Peter Ralph, David Peede, Ilan Gronau (slack channel: #dec9-10_americas)\n",
     "\n",
     "### Australasia\n",
     "\n",
@@ -37,14 +37,14 @@
     "\n",
     "**Instructor:** Georgia Tsambos, University of Melbourne\n",
     "\n",
-    "**Helpers:** Murillo Rodrigues, Peter Ralph \n",
+    "**Helpers:** Murillo Rodrigues, Peter Ralph (slack channel: #dec10-11_australasia)\n",
     "\n",
     "## Workshop logistics\n",
     "\n",
     "**Participants:** If you want, introduce yourselves in the Slack chat. What's your name? Where are you located? What do you work on?\n",
     "\n",
     "**Banter/Questions**\n",
-    "Please use the Slack #intro-workshop channel for participant-participant help and chat. To ask a general question, simply write it in the channel, and to ask for one-one help DM one of the helpers in your session.\n",
+    "Please use the Slack channel you were invited to for participant-participant help and chat. To ask a general question, simply write it in the channel, and to ask for one-one help DM one of the helpers in your session.\n",
     "\n",
     "This worksheet was created by Ariella Gladstein, a postdoc at University of North Carolina, Chapel Hill."
    ]
@@ -963,7 +963,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Whoops; I did this concurrently to #8, but this fix puts in info for other workshops, too (and also updates fillme).

Closes #7.